### PR TITLE
Update env_logger to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.6"
-env_logger = "0.6.0"
+env_logger = "0.7.1"
 
 [dev-dependencies]
 tempfile = "3.0.5"


### PR DESCRIPTION
This avoids introducing duplicate versions of env_logger in crates that
depend on both env_logger 0.7 and file-per-thread-logger.