### PR TITLE
Add feature for custom log format

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,5 +22,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build
-    - name: Run tests
-      run: cargo test --all --verbose
+    # Formatted and unformatted should run separately since Cargo uses multiple threads for tests
+    - name: Test unformatted logs
+      run: cargo test tests --verbose
+    - name: Test formatted logs
+      run: cargo test formatted_logs --verbose

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,12 +1,12 @@
 use tempfile::tempdir;
 
-use file_per_thread_logger::initialize;
+use file_per_thread_logger::{initialize, initialize_with_formatter, FormatFn};
 
 use log::{debug, error, info, trace, warn};
 use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::thread;
 
 const LOG_PREFIX: &str = "my_log_test-";
@@ -38,7 +38,7 @@ fn flush() {
     log::logger().flush();
 }
 
-fn do_log(run_init: bool) -> thread::ThreadId {
+fn do_log(run_init: bool, formatter: Option<FormatFn>) -> thread::ThreadId {
     trace!("This is a trace entry on the main thread.");
     debug!("This is a debug entry on the main thread.");
     info!("This is an info entry on the main thread.");
@@ -47,7 +47,11 @@ fn do_log(run_init: bool) -> thread::ThreadId {
 
     let handle = thread::spawn(move || {
         if run_init {
-            initialize(LOG_PREFIX);
+            if let Some(formatter) = formatter {
+                initialize_with_formatter(LOG_PREFIX, formatter);
+            } else {
+                initialize(LOG_PREFIX);
+            }
         }
         trace!("This is a trace entry from an unnamed helper thread.");
         debug!("This is a debug entry from an unnamed helper thread.");
@@ -64,7 +68,11 @@ fn do_log(run_init: bool) -> thread::ThreadId {
         .name("helper".to_string())
         .spawn(move || {
             if run_init {
-                initialize(LOG_PREFIX);
+                if let Some(formatter) = formatter {
+                    initialize_with_formatter(LOG_PREFIX, formatter);
+                } else {
+                    initialize(LOG_PREFIX);
+                }
             }
             trace!("This is a trace entry from a named thread.");
             debug!("This is a debug entry from a named thread.");
@@ -93,7 +101,7 @@ fn tests() -> io::Result<()> {
 
     // Nothing should be logged without something in the RUST_LOG env variable..
     assert_eq!(log_files()?, set(&[]));
-    do_log(false);
+    do_log(false, None);
     assert_eq!(log_files()?, set(&[]));
 
     // When the RUST_LOG variable is set, it will create the main thread file even though nothing
@@ -112,7 +120,7 @@ fn tests() -> io::Result<()> {
 "#
     );
 
-    let unnamed_thread_id = do_log(true);
+    let unnamed_thread_id = do_log(true, None);
     let unnamed_log = format!("{:?}", unnamed_thread_id);
     let unnamed_log = &unnamed_log
         .chars()
@@ -146,6 +154,67 @@ ERROR - This is an error entry from a named thread.
 "#
     );
 
+    temp_dir.close()?;
+    Ok(())
+}
+
+#[test]
+fn formatted_logs() -> io::Result<()> {
+    let temp_dir = tempdir()?;
+    env::set_current_dir(&temp_dir)?;
+    let formatter: FormatFn = |writer, record| {
+        writeln!(
+            writer,
+            "{} [{}:{}] {}",
+            record.level(),
+            record.file().unwrap_or_default(),
+            record.line().unwrap_or_default(),
+            record.args()
+        )
+    };
+
+    // When the RUST_LOG variable is set, it will create the main thread file even though nothing
+    // has been logged yet.
+    env::set_var("RUST_LOG", "info");
+    initialize_with_formatter(LOG_PREFIX, formatter);
+    flush();
+
+    let main_log = "formatted_logs";
+    let named_log = "helper";
+
+    assert_eq!(log_files()?, set(&[main_log]));
+    assert_eq!(
+        read_log(main_log)?,
+        r#"INFO [src/lib.rs:90] Set up logging; filename prefix is my_log_test-
+"#
+    );
+
+    let unnamed_thread_id = do_log(true, Some(formatter));
+    let unnamed_log = format!("{:?}", unnamed_thread_id);
+    let unnamed_log = &unnamed_log
+        .chars()
+        .filter(|ch| ch.is_alphanumeric() || *ch == '-' || *ch == '_')
+        .collect::<String>();
+
+    // It then creates files for each thread with logged contents.
+    assert_eq!(log_files()?, set(&[main_log, named_log, unnamed_log]));
+
+    assert_eq!(
+        read_log(unnamed_log)?,
+        r#"INFO [src/lib.rs:90] Set up logging; filename prefix is my_log_test-
+INFO [tests/test.rs:58] This is an info entry from an unnamed helper thread.
+WARN [tests/test.rs:59] This is a warn entry from an unnamed helper thread.
+ERROR [tests/test.rs:60] This is an error entry from an unnamed helper thread.
+"#
+    );
+    assert_eq!(
+        read_log(named_log)?,
+        r#"INFO [src/lib.rs:90] Set up logging; filename prefix is my_log_test-
+INFO [tests/test.rs:79] This is an info entry from a named thread.
+WARN [tests/test.rs:80] This is a warn entry from a named thread.
+ERROR [tests/test.rs:81] This is an error entry from a named thread.
+"#
+    );
     temp_dir.close()?;
     Ok(())
 }


### PR DESCRIPTION
Hi there. I was looking for solution to get separate log files for separate threads and I came across this crate. It's super useful, thanks. However, I was not able to format the log messages in a custom format.

I have added the feature to the API along with instructions in the README and relevant tests. Could you take a look and accept this change. I'm happy to make any changes if required.